### PR TITLE
fix: convert HSL to OKLCH color format for tailwindcss v4

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -80,10 +80,10 @@ export const resolveTwcConfig = <ThemeName extends string>(
 
          try {
             const cssVar = produceCssVariable(colorName)
-            const oklch = new Color(colorValue).to('oklch')
+            const color = new Color(colorValue).to('oklch').toString({ format: 'css', precision: 3, inGamut: true })
 
-            resolved.utilities[cssSelector][cssVar] = `${oklch.l * 100}% ${oklch.c} ${oklch.h}`
-            resolved.colors[colorName] = `oklch(var(${cssVar}) / <alpha-value>)`
+            resolved.utilities[cssSelector][cssVar] = color
+            resolved.colors[colorName] = `var(${cssVar})`
          } catch (error: any) {
             const message = `\r\nWarning - In theme "${themeName}" color "${colorName}". ${error.message}`;
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,11 @@
       "tailwindcss": ">=4.0.0"
    },
    "dependencies": {
-      "color": "^4.2.3",
+      "colorjs.io": "^0.5.2",
       "flat": "^5.0.2",
       "lodash.foreach": "^4.5.0"
    },
    "devDependencies": {
-      "@types/color": "^4.2.0",
       "@types/flat": "^5.0.2",
       "@types/lodash.foreach": "^4.5.9",
       "@types/node": "^22.10.10",


### PR DESCRIPTION
When using Tailwind CSS v4's new color format (OKLCH), attempting to parse existing color values results in errors because the Color library doesn't support OKLCH colors.

For example, trying to use the tailwindcss default colors it throws:
`Warning - In theme "dark" color "danger". Unable to parse color from string: oklch(0.637 0.237 25.331)`

This PR:
- replaces the `color` npm package with `colorjs.io` which has native OKLCH support
- parses and converts all color formats (HEX, RGB, HSL) to OKLCH
- removes `<alpha-value>` mapping as tailwind now handles this using `color-mix`

The update allows use of both existing color values and OKLCH colors in theme configurations.